### PR TITLE
fix: Solve timezones for app slots bug back-end

### DIFF
--- a/lib/availability/getPotentialTimes.ts
+++ b/lib/availability/getPotentialTimes.ts
@@ -23,8 +23,8 @@ export default function getPotentialTimes({
 
   // Sort the slots by start time
   const days = eachDayOfInterval({
-    start: start.toInterval().start,
-    end: end.toInterval().end,
+    start: start.toInterval("Etc/GMT").start,
+    end: end.toInterval("Etc/GMT").end,
   })
   days.forEach((day) => {
     const dayOfWeek = day.getDay()

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -52,8 +52,8 @@ function Page({
 
   const slots = offers.filter((slot) => {
     return (
-      slot.start >= startDay.toInterval().start &&
-      slot.end <= endDay.toInterval().end
+      slot.start >= startDay.toInterval("Etc/GMT").start &&
+      slot.end <= endDay.toInterval("Etc/GMT").end
     )
   })
 


### PR DESCRIPTION
Day.toInterval needed to be supplied UTC timezone to allow for event times to properly overlap